### PR TITLE
Swap footer email link for LinkedIn

### DIFF
--- a/src/config/social.json
+++ b/src/config/social.json
@@ -3,7 +3,7 @@
   "twitter": "https://twitter.com/",
   "instagram": "https://instagram.com/",
   "youtube": "https://youtube.com/",
-  "linkedin": "https://linkedin.com/",
+  "linkedin": "https://www.linkedin.com/in/rileydustin",
   "github": "",
   "gitlab": "",
   "medium": "",

--- a/src/layouts/partials/Footer.astro
+++ b/src/layouts/partials/Footer.astro
@@ -1,10 +1,9 @@
 ---
-import config from "@/config/config.json";
 import social from "@/config/social.json";
 
 const year = new Date().getFullYear();
 const githubUrl = social.github || "https://github.com/dustin-riley";
-const email = config.contactinfo.email;
+const linkedinUrl = social.linkedin;
 ---
 
 <footer class="ds-container">
@@ -12,8 +11,8 @@ const email = config.contactinfo.email;
     <div>© {year} Dustin Riley</div>
     <div class="links">
       <a href={githubUrl} rel="noopener noreferrer" target="_blank">github ↗</a>
+      <a href={linkedinUrl} rel="noopener noreferrer" target="_blank">linkedin ↗</a>
       <a href="/rss.xml">rss</a>
-      <a href={`mailto:${email}`}>email</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Replace the footer's mailto link with a LinkedIn link styled like the existing GitHub link (external, opens in a new tab, with the ↗ arrow)
- Update `social.json` with the actual LinkedIn profile URL

## Test plan
- [ ] Verify the footer renders `github ↗`, `linkedin ↗`, and `rss` links in that order
- [ ] Confirm the LinkedIn link opens https://www.linkedin.com/in/rileydustin in a new tab
- [ ] Confirm the email link is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)