### PR TITLE
Clip horizontal overflow on html to fix mobile zoom-out gap

### DIFF
--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -4,6 +4,7 @@
 
 html {
   font-size: 16px;
+  overflow-x: clip;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Decorative blobs on the home page (`.hero .blob-1` at `right: -120px`) and about page (`.about-header .blob` at `right: -100px`) extend past the right viewport edge
- `overflow-x: clip` was set on `body` only, but iOS Safari still computed the layout viewport wider than the visual viewport — pinch-zooming out revealed empty space on the right of the page
- Adding `overflow-x: clip` to `html` as well constrains the layout viewport itself, so there is nothing extra to reveal when zooming out

## Test plan
- [ ] Load the site on a phone, pinch-zoom out — page edges should hold, no empty area on the right
- [ ] Verify desktop layout is unchanged
- [ ] Confirm the decorative blobs still render in their intended positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)